### PR TITLE
Filesystem: Added EEXIST reporting to mkdir through errno

### DIFF
--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -28,6 +28,7 @@
 #include "FATFileHandle.h"
 #include "FATDirHandle.h"
 #include "critical.h"
+#include <errno.h>
 
 DWORD get_fattime(void) {
     time_t rawtime;
@@ -178,6 +179,9 @@ DirHandle *FATFileSystem::opendir(const char *name) {
 int FATFileSystem::mkdir(const char *name, mode_t mode) {
     lock();
     FRESULT res = f_mkdir(name);
+    if (res != 0) {
+        errno = (res == FR_EXIST) ? EEXIST : 0;
+    }
     unlock();
     return res == 0 ? 0 : -1;
 }


### PR DESCRIPTION
Just poking errno into the filesystem api seems like the quickest path for now. We can standardize how to propogate errors from the filesystem in a way consistent with mbed later.

Related to STORAGE_ISSUE_0007 on https://github.com/ARMmbed/mbed-os/issues/3572

cc @simonqhughes